### PR TITLE
Fix for Python >= 3.5

### DIFF
--- a/YahooTickerDownloader.py
+++ b/YahooTickerDownloader.py
@@ -135,7 +135,10 @@ def main():
                 
         with open(downloader.type + '.csv', 'wb') as f:
             if sys.version_info.major >= 3:
-                f.write(data.csv.decode('UTF-8'))
+                if sys.version_info.major == 3 and sys.version_info.minor < 5:
+                    f.write(data.csv.decode('UTF-8'))
+                else:
+                    f.write(data.csv.encode('UTF-8'))
             else:
                 f.write(data.csv)
 

--- a/ytd/SymbolDownloader.py
+++ b/ytd/SymbolDownloader.py
@@ -15,7 +15,7 @@ class SymbolDownloader:
         self.rsession = requests.Session()
         self.type = type
 
-        self.queries = string.ascii_lowercase;
+        self.queries = string.ascii_lowercase
         self.current_q = self.queries[0]
         self.current_q_item_offset = 0
         self.current_q_total_items = 'Unknown'  # This field is normally a int
@@ -139,7 +139,7 @@ class SymbolDownloader:
             print("Progress: Done!")
         else:
             print("Progress:" +
-                " Query " + str(self._getQueryIndex()) + "/" + str(self.getTotalQueries()) + "."
+                " Query " + str(self._getQueryIndex()+1) + "/" + str(self.getTotalQueries()) + "."
                 " Items handled in current query: " + str(self.current_q_item_offset) + "/" + str(self.current_q_total_items) + "."
                 " Total collected unique " + self.type + " entries: " + str(len(self.symbols))
                 )


### PR DESCRIPTION
I'm using Python 3.5 and 3.6 and the latest "tablib" (0.11.4). This fix checks for Python >= 3.5 (this might be wrong!), however I've not tested this with Python < 3.5, the problem will be from Python >= 3.5 or the current tablib version. The source of this problem has to be determined.