### PR TITLE
market parameter exposed to cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,24 +36,29 @@ Example Usage
 .. code::
 
     usage: YahooTickerDownloader.py [-h] [-i] [-e] [-E EXCHANGE] [-s SLEEP] [-p]
+                                    [-m MARKET]
                                     type
 
     positional arguments:
-      type                  The type to download, this can be: mutualfund index
-                            bond etf warrant stocks future currency
+      type                  The type to download, this can be: future mutualfund
+                        etf stocks index currency
 
     optional arguments:
       -h, --help            show this help message and exit
       -i, --insecure        use HTTP instead of HTTPS
-      -e, --export          export immediately without downloading (Only useful
-                            if you already downloaded something to the .pickle
-                            file)
+      -e, --export          export immediately without downloading (Only useful if
+                            you already downloaded something to the .pickle file)
       -E EXCHANGE, --Exchange EXCHANGE
                             Only export ticker symbols from this exchange (the
                             filtering is done during the export phase)
       -s SLEEP, --sleep SLEEP
                             The time to sleep in seconds between requests
       -p, --pandantic       Stop and warn the user if some rare assertion fails
+      -m MARKET, --market MARKET
+                            Specify the Region of queried exchanges (us =
+                            USA+Canada, dr=Germany, fr=France, hk=Hongkong,
+                            gb=United Kingdom, default= all)
+
 
 The first positional argument must be one of the following: ``stocks`` ``etf``
 ``future`` ``index`` ``mutualfund`` ``currency`` ``warrant`` ``bond``
@@ -64,7 +69,8 @@ For example to download all stock symbols you run it like:
 
     YahooTickerDownloader.py stocks
 
-The program takes several days before it is finished.
+The program takes several hours before it is finished so if you don't need all symbols 
+it might be a good idea to specify the Region of the exchanges you're interested in.
 The program supports suspending and resuming a download.
 Press CTRL+C to suspend download. Restart the program
 in the same working directory to resume downloading.

--- a/YahooTickerDownloader.py
+++ b/YahooTickerDownloader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import pickle
 from time import sleep

--- a/YahooTickerDownloader.py
+++ b/YahooTickerDownloader.py
@@ -76,7 +76,7 @@ def main():
     parser.add_argument('type', help='The type to download, this can be: '+" ".join(list(options.keys())))
     parser.add_argument("-s", "--sleep", help="The time to sleep in seconds between requests", type=float, default=0)
     parser.add_argument("-p", "--pandantic", help="Stop and warn the user if some rare assertion fails", action="store_true")
-    parser.add_argument("-m", "--market", help="Specify the Region of queried exchanges (us = USA+Canada, dr=Germany, fr=France, hk=Hongkong, gb=United Kingdom, default= all", default="all")
+    parser.add_argument("-m", "--market", help="Specify the Region of queried exchanges (us = USA+Canada, dr=Germany, fr=France, hk=Hongkong, gb=United Kingdom, default= all)", default="all")
 
     args = parser.parse_args()
 

--- a/YahooTickerDownloader.py
+++ b/YahooTickerDownloader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import pickle
 from time import sleep
@@ -38,12 +38,12 @@ def saveDownloader(downloader, tickerType):
         pickle.dump(downloader, file=f, protocol=pickle.HIGHEST_PROTOCOL)
 
 
-def downloadEverything(downloader, tickerType, insecure, sleeptime, pandantic):
+def downloadEverything(downloader, tickerType, insecure, sleeptime, pandantic, market):
 
     loop = 0
     while not downloader.isDone():
 
-        symbols = downloader.nextRequest(insecure, pandantic)
+        symbols = downloader.nextRequest(insecure, pandantic, market)
         print("Got " + str(len(symbols)) + " downloaded " + downloader.type + " symbols:")
         if(len(symbols) > 2):
             try:
@@ -76,6 +76,8 @@ def main():
     parser.add_argument('type', help='The type to download, this can be: '+" ".join(list(options.keys())))
     parser.add_argument("-s", "--sleep", help="The time to sleep in seconds between requests", type=float, default=0)
     parser.add_argument("-p", "--pandantic", help="Stop and warn the user if some rare assertion fails", action="store_true")
+    parser.add_argument("-m", "--market", help="Specify the Region of queried exchanges (us = USA+Canada, dr=Germany, fr=France, hk=Hongkong, gb=United Kingdom, default= all", default="all")
+
     args = parser.parse_args()
 
     if args.insecure:
@@ -85,6 +87,8 @@ def main():
         print("Exporting pickle file")
 
     tickerType = args.type = args.type.lower()
+
+    market = args.market = args.market.lower()
 
     print("Checking if we can resume a old download session")
     try:
@@ -104,7 +108,7 @@ def main():
             if not downloader.isDone():
                 print("Downloading " + downloader.type)
                 print("")
-                downloadEverything(downloader, tickerType, args.insecure, args.sleep, args.pandantic)
+                downloadEverything(downloader, tickerType, args.insecure, args.sleep, args.pandantic, market)
                 print ("Saving downloader to disk...")
                 saveDownloader(downloader, tickerType)
                 print ("Downloader successfully saved.")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'Yahoo-ticker-downloader',
-    version = '2.0.1',
+    version = '2.0.2',
     author = 'Benny Jacobs',
     author_email = 'Benny@GMX.it',
     url='https://github.com/Benny-/Yahoo-ticker-symbol-downloader',

--- a/ytd/SymbolDownloader.py
+++ b/ytd/SymbolDownloader.py
@@ -25,6 +25,7 @@ class SymbolDownloader:
         self.query_done_max = 3
         self.current_page_retries = 0
         self.done = False
+        self.market = 'all'
 
     def _add_queries(self, prefix=''):
         # This method will add (prefix+)a...z to self.queries
@@ -40,8 +41,9 @@ class SymbolDownloader:
             encoded += ';' + quote(key) + '=' + quote(text(value))
         return encoded
 
-    def _fetch(self, insecure):
+    def _fetch(self, insecure, market):
         params = {
+            'm': market,
             'b': text(self.current_q_item_offset),
             's': self.current_q,
             't': self.type[0].upper(),
@@ -88,7 +90,7 @@ class SymbolDownloader:
         else:
             self.current_q = self.queries[self._getQueryIndex() + 1]
 
-    def nextRequest(self, insecure=False, pandantic=False):
+    def nextRequest(self, insecure=False, pandantic=False, market='all'):
 
         # You would expect query_done to be a boolean.
         # But unfortunaly we can't depend on Yahoo telling use if there
@@ -105,7 +107,7 @@ class SymbolDownloader:
         # respectively.
         while(success == False):
             try:
-                json = self._fetch(insecure)
+                json = self._fetch(insecure, market)
                 success = True
             except (requests.HTTPError,
                     requests.exceptions.ChunkedEncodingError,


### PR DESCRIPTION
since a download with m='all' takes a pretty long time I tried to expose the parameter to the cli.
Seems to work. (only tested with stocks!)
One caveat though: if you resume a download and don't use the parameter it falls back to the default (all). 