### PR TITLE
Yahoo api update

### DIFF
--- a/YahooTickerDownloader.py
+++ b/YahooTickerDownloader.py
@@ -6,12 +6,14 @@ import argparse
 import io
 
 from ytd import SymbolDownloader
+from ytd import SimpleSymbolDownloader
 from ytd.downloader.StockDownloader import StockDownloader
 from ytd.downloader.ETFDownloader import ETFDownloader
 from ytd.downloader.FutureDownloader import FutureDownloader
 from ytd.downloader.IndexDownloader import IndexDownloader
 from ytd.downloader.MutualFundDownloader import MutualFundDownloader
 from ytd.downloader.CurrencyDownloader import CurrencyDownloader
+from ytd.downloader.GenericDownloader import GenericDownloader
 from ytd.compat import text
 from ytd.compat import csv
 from reppy.robots import Robots
@@ -29,7 +31,7 @@ options = {
     "index": IndexDownloader(),
     "mutualfund": MutualFundDownloader(),
     "currency": CurrencyDownloader(),
-    "generic": GenericSymbolDownloader()
+    "generic": GenericDownloader()
 }
 
 

--- a/YahooTickerDownloader.py
+++ b/YahooTickerDownloader.py
@@ -29,6 +29,7 @@ options = {
     "index": IndexDownloader(),
     "mutualfund": MutualFundDownloader(),
     "currency": CurrencyDownloader(),
+    "generic": GenericSymbolDownloader()
 }
 
 

--- a/ytd/SimpleSymbolDownloader.py
+++ b/ytd/SimpleSymbolDownloader.py
@@ -1,0 +1,147 @@
+import requests
+import string
+from time import sleep
+import math
+
+from ytd.compat import text
+from ytd.compat import quote
+
+user_agent = 'yahoo-ticker-symbol-downloader'
+search_characters = 'abcdefghijklmnopqrstuvwxyz0123456789.='
+
+class SymbolDownloader:
+    """Abstract class"""
+
+    def __init__(self, type):
+        # All downloaded symbols are stored in a dict before exporting
+        # This is to ensure no duplicate data
+        self.symbols = {}
+        self.rsession = requests.Session()
+        self.type = type
+
+        self.queries = []
+        self._add_queries()
+        self.current_q = self.queries[0]
+        self.done = False
+
+    def _add_queries(self, prefix=''):
+        # This method will add (prefix+)a...z to self.queries
+
+        for i in range(len(search_characters)):
+            element = str(prefix) + str(search_characters[i])
+            if element not in self.queries:  # Avoid having duplicates in list
+                self.queries.append(element)
+
+    def _encodeParams(self, params):
+        encoded = ''
+        for key, value in params.items():
+            encoded += ';' + quote(key) + '=' + quote(text(value))
+        return encoded
+
+    def _fetch(self, insecure, market):
+        params = {
+            'searchTerm': self.current_q,
+        }
+        query_string = {
+            'device': 'console',
+            'returnMeta': 'true',
+        }
+        protocol = 'http' if insecure else 'https'
+        req = requests.Request('GET',
+            protocol+'://finance.yahoo.com/_finance_doubledown/api/resource/searchassist;'+self._encodeParams(params),
+            headers={'User-agent': user_agent},
+            params=query_string
+        )
+        req = req.prepare()
+        print("req " + req.url)
+        resp = self.rsession.send(req, timeout=(12, 12))
+        resp.raise_for_status()
+
+        return resp.json()
+
+    def decodeSymbolsContainer(self, symbolsContainer):
+        raise Exception("Function to extract symbols must be overwritten in subclass. Generic symbol downloader does not know how.")
+
+    def _getQueryIndex(self):
+        return self.queries.index(self.current_q)
+
+    def getTotalQueries(self):
+        return len(self.queries)
+
+    def _nextQuery(self):
+        if self._getQueryIndex() + 1 >= len(self.queries):
+            self.current_q = self.queries[0]
+        else:
+            self.current_q = self.queries[self._getQueryIndex() + 1]
+
+    def nextRequest(self, insecure=False, pandantic=False, market='all'):
+        self._nextQuery()
+        success = False
+        retryCount = 0
+        json = None
+        # Eponential back-off algorithm
+        # to attempt 3 more times sleeping 5, 25, 125 seconds
+        # respectively.
+        while(success == False):
+            try:
+                json = self._fetch(insecure, market)
+                success = True
+            except (requests.HTTPError,
+                    requests.exceptions.ChunkedEncodingError,
+                    requests.exceptions.ReadTimeout,
+                    requests.exceptions.ConnectionError) as ex:
+                if retryCount < 3:
+                    attempt = retryCount + 1
+                    sleepAmt = int(math.pow(5,attempt))
+                    print("Retry attempt: " + str(attempt) + "."
+                        " Sleep period: " + str(sleepAmt) + " seconds."
+                        )
+                    sleep(sleepAmt)
+                    retryCount = attempt
+                else:
+                    raise
+
+        (symbols, count) = self.decodeSymbolsContainer(json)
+
+        for symbol in symbols:
+            self.symbols[symbol.ticker] = symbol
+
+        # There is no pagination with this API.
+				# If we receive 10 results, we assume there are more than 10 and add another layer of queries to narrow the search further
+        if(count == 10):
+            self._add_queries(self.current_q)
+        elif(count > 10):
+            # This should never happen with this API, it always returns at most 10 items
+            raise Exception("Funny things are happening: count "
+                            + text(count)
+                            + " > 10. "
+                            + "Content:"
+                            + "\n"
+                            + repr(json))
+
+        if self._getQueryIndex() + 1 >= len(self.queries):
+            self.done = True
+        else:
+            self.done = False
+
+        return symbols
+
+    def isDone(self):
+        return self.done
+
+    def getCollectedSymbols(self):
+        return self.symbols.values()
+
+    def getRowHeader(self):
+        return ["Ticker", "Name", "Exchange"]
+
+    def printProgress(self):
+        if self.isDone():
+            print("Progress: Done!")
+        else:
+            print("Progress:"
+                + " Query " + str(self._getQueryIndex()+1) + "/" + str(self.getTotalQueries()) + "."
+                + "\n"
+                + str(len(self.symbols)) + " unique " + self.type + " entries collected so far."
+                )
+        print ("")

--- a/ytd/SimpleSymbolDownloader.py
+++ b/ytd/SimpleSymbolDownloader.py
@@ -7,7 +7,8 @@ from ytd.compat import text
 from ytd.compat import quote
 
 user_agent = 'yahoo-ticker-symbol-downloader'
-search_characters = 'abcdefghijklmnopqrstuvwxyz0123456789.='
+general_search_characters = 'abcdefghijklmnopqrstuvwxyz0123456789.='
+first_search_characters = 'abcdefghijklmnopqrstuvwxyz'
 
 class SymbolDownloader:
     """Abstract class"""
@@ -26,6 +27,12 @@ class SymbolDownloader:
 
     def _add_queries(self, prefix=''):
         # This method will add (prefix+)a...z to self.queries
+        # This API requires the first character of the search to be a letter.
+        # The second character can be a letter, number, dot, or equals sign.
+        if len(prefix)==0:
+            search_characters = first_search_characters
+        else:
+            search_characters = general_search_characters
 
         for i in range(len(search_characters)):
             element = str(prefix) + str(search_characters[i])
@@ -48,7 +55,7 @@ class SymbolDownloader:
         }
         protocol = 'http' if insecure else 'https'
         req = requests.Request('GET',
-            protocol+'://finance.yahoo.com/_finance_doubledown/api/resource/searchassist;'+self._encodeParams(params),
+            protocol+'://finance.yahoo.com/_finance_doubledown/api/resource/searchassist'+self._encodeParams(params),
             headers={'User-agent': user_agent},
             params=query_string
         )

--- a/ytd/downloader/GenericDownloader.py
+++ b/ytd/downloader/GenericDownloader.py
@@ -1,0 +1,29 @@
+from ..SymbolDownloader import SymbolDownloader
+from ..symbols.Generic import Generic
+
+from ..compat import text
+
+class GenericDownloader(SymbolDownloader):
+    def __init__(self):
+        SymbolDownloader.__init__(self, "generic")
+
+    def decodeSymbolsContainer(self, json):
+        symbols = []
+        count = 0
+
+        for row in json['data']['items']:
+            ticker = text(row['symbol'])
+            name = row['name']
+            exchange = row['exch']
+            exchangeDisplay = row['exchDisp']
+            symbolType = row['type']
+            symbolTypeDisplay = row['typeDisp']
+            symbols.append(Generic(ticker, name, exchange, exchangeDisplay, symbolType, symbolTypeDisplay))
+
+        count = len(json['data']['items'])
+
+        return (symbols, count)
+
+    def getRowHeader(self):
+        return SymbolDownloader.getRowHeader(self) + ["exchangeDisplay", "Type", "TypeDisplay"]
+

--- a/ytd/downloader/GenericDownloader.py
+++ b/ytd/downloader/GenericDownloader.py
@@ -1,4 +1,4 @@
-from ..SymbolDownloader import SymbolDownloader
+from ..SimpleSymbolDownloader import SymbolDownloader
 from ..symbols.Generic import Generic
 
 from ..compat import text

--- a/ytd/symbols/Generic.py
+++ b/ytd/symbols/Generic.py
@@ -1,0 +1,14 @@
+from ytd.Symbol import Symbol
+
+class Generic(Symbol):
+    def __init__(self, ticker, name, exchange, exchangeDisplay, symbolType, symbolTypeDisplay):
+        Symbol.__init__(self, ticker, name, exchange)
+        self.exchangeDisplay = exchangeDisplay
+        self.symbolType = symbolType
+        self.symbolTypeDisplay = symbolTypeDisplay
+
+    def getType(self):
+        return 'Generic'
+
+    def getRow(self):
+        return Symbol.getRow(self) + [self.exchangeDisplay, self.symbolType, self.symbolTypeDisplay]


### PR DESCRIPTION
This pull request creates a new symbol type, "generic", and an associated downloader, that uses the Yahoo symbol search API instead of the older deprecated API.

The new Yahoo API does not support the same options as the old API -- it doesn't support filtering by market, or pagination -- and it doesn't seem to have some of the issues of the old one (e.g. being unpredictable in terms of returning blank results).  It also returns different fields.

So the resulting downloader is simpler but also more inefficient, because if we get back 10 results, the only way we can try to get everything is to expand the search query by one character and run through all possibilities.

This pull request leaves the old download and symbol types in place, as I wasn't sure if there were elements of those that could/should be salvaged.